### PR TITLE
Add support for RISC-V OpenOCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ If you have macOS Big Sur (11), `riscv-tools` will be installed from precompiled
 
     $ brew install --cc=gcc-10 riscv-tools
 
+Due to high number of dependences the RISC-V version of OpenOCD is not installed by default. If needed, it can be installed with:
+
+    $ brew install riscv-openocd
 
 Testing
 -------

--- a/riscv-openocd.rb
+++ b/riscv-openocd.rb
@@ -1,0 +1,31 @@
+class RiscvOpenocd < Formula
+  desc "Fork of OpenOCD with RISC-V support"
+  homepage "https://github.com/riscv/riscv-openocd.git"
+  #head "https://github.com/riscv/riscv-openocd.git", branch: "riscv"
+  url "https://github.com/riscv/riscv-openocd.git", branch: "riscv"
+  version "riscv"
+
+  keg_only "it conflicts with `openocd`"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "texinfo" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "capstone"
+  depends_on "hidapi"
+  depends_on "libftdi"
+  depends_on "libusb"
+  depends_on "libusb-compat"
+
+  def install
+    system "./bootstrap", "nosubmodule"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    system "false"
+  end
+end

--- a/riscv-tools.rb
+++ b/riscv-tools.rb
@@ -7,6 +7,7 @@ class RiscvTools < Formula
 
   # install rest of tools
   depends_on "riscv-gnu-toolchain"
+  depends_on "riscv-openocd"
   depends_on "riscv-isa-sim"
   depends_on "riscv-pk"
 

--- a/riscv-tools.rb
+++ b/riscv-tools.rb
@@ -7,7 +7,6 @@ class RiscvTools < Formula
 
   # install rest of tools
   depends_on "riscv-gnu-toolchain"
-  depends_on "riscv-openocd"
   depends_on "riscv-isa-sim"
   depends_on "riscv-pk"
 


### PR DESCRIPTION
This PR adds support for installing the  RISC-V version of OpenOCD. 

Since the [repository](https://github.com/riscv/riscv-openocd) does not seem to tag versions I followed the example from other recipes and used the repository as the `url` and branch name as the `version`. This recipe installs cleanly on macOS Catalina 10.15.7 (19H1323). Recipe installs as a keg because it conflicts with the vanilla OpenOCD provided by Homebrew.

I can successfully compile and upload [Nuclei SDK examples](https://github.com/Nuclei-Software/nuclei-sdk/tree/master/application/baremetal) to a Longan Nano board. I have not tried with any other boards.

```
$ make SOC=gd32vf103 BOARD=gd32vf103c_longan_nano upload
...
JTAG tap: riscv.cpu tap/device found: 0x1000563d (mfg: 0x31e (Andes Technology Corporation), part: 0x0005, ver: 0x1)
JTAG tap: auto0.tap tap/device found: 0xffffffff (mfg: 0x7ff (<invalid>), part: 0xffff, ver: 0xf)
Loading section .init, size 0x26c lma 0x8000000
Loading section .text, size 0x241e lma 0x8000280
Loading section .rodata, size 0x484 lma 0x80026a0
Loading section .data, size 0x6c lma 0x8002b24
Start address 0x0800015c, load size 11130
Transfer rate: 6 KB/sec, 2782 bytes/write.
A debugging session is active.

	Inferior 1 [Remote target] will be detached.

Quit anyway? (y or n) [answered Y; input not from terminal]
[Inferior 1 (Remote target) detached]
$
```