### PR TITLE
Missing "texinfo" build dependency in riscv-gnu-toolchain

### DIFF
--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -40,6 +40,7 @@ class RiscvGnuToolchain < Formula
   depends_on "gawk" => :build
   depends_on "gnu-sed" => :build
   depends_on "flock" => :build
+  depends_on "texinfo" => :build
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"


### PR DESCRIPTION
When building on the latest macOS 13.0 you get the following error when building:

    makeinfo: command not found
    WARNING: 'makeinfo' is missing on your system.

This patch adds the "texinfo" build dependency that contains the 'makeinfo' command.

Signed-off-by: Jon Eyolfson <jon@eyolfson.com>