### PR TITLE
Add Apple Silicon bottles for macOS Ventura

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Build the toolchain:
 
     $ brew install riscv-tools
 
-If you have macOS Ventura (13), `riscv-tools` will be installed from precompiled binaries. If you do not have Ventura (for x86), `riscv-tools` will be built from source. Note building from source will require approximately 6.5 GB for all of the source and intermediate build files. It builds with the default compiler (clang), but you can specify another compiler on the command line. For example:
+If you have macOS Ventura (13), `riscv-tools` will be installed from precompiled binaries, for either Intel or Apple Silicon. If you do not have Ventura, `riscv-tools` will be built from source. Note building from source will require approximately 6.5 GB for all of the source and intermediate build files. It builds with the default compiler (clang), but you can specify another compiler on the command line. For example:
 
     $ brew install --cc=gcc-10 riscv-tools
 

--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -30,8 +30,9 @@ class RiscvGnuToolchain < Formula
 
   bottle do
     root_url "http://riscv.org.s3.amazonaws.com/bottles"
-    rebuild 12
+    rebuild 13
     sha256 ventura: "d38930d0e52ed36c72f2985fc5cc0b032f0109e745bbfa35c3cf485428687736"
+    sha256 arm64_ventura: "815059334a5de53f2eeec849f91d70db2c33c3d33109134154f355eada9bc5f4"
   end
 
   # enabling multilib by default, must choose to build without

--- a/riscv-isa-sim.rb
+++ b/riscv-isa-sim.rb
@@ -6,8 +6,9 @@ class RiscvIsaSim < Formula
 
   bottle do
     root_url "http://riscv.org.s3.amazonaws.com/bottles"
-    rebuild 14
+    rebuild 15
     sha256 cellar: :any, ventura: "02b56f3cace2ad901f2bea580a5d041815742d79e7cde5167e363f4df108159f"
+    sha256 cellar: :any, arm64_ventura: "841e5d077ffa403ebf7c6b7dd3b610e985b2161e7adcbf6aecedf946bdf4c32c"
   end
 
   depends_on "dtc"

--- a/riscv-pk.rb
+++ b/riscv-pk.rb
@@ -6,8 +6,9 @@ class RiscvPk < Formula
 
   bottle do
     root_url "http://riscv.org.s3.amazonaws.com/bottles"
-    rebuild 12
+    rebuild 13
     sha256 cellar: :any_skip_relocation, ventura: "4ef896ae9c3f097a68a43e7c39183d964822ad484c0e84af4d16280b9460f8f4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f79950ba570e4e984565744e32fe5935bdbcbe71a6beda925aff9997d64df958"
   end
 
   depends_on "gnu-sed" => :build


### PR DESCRIPTION
I built these in a clean Homebrew install in virtual machine. Attaching the full output of the build as [`results.txt`][1]. Here are the files:

```
> ll *.tar.gz
-rw-r--r--@ 1 dave  staff    76M Apr  6 21:22 riscv-gnu-toolchain--main.arm64_ventura.bottle.13.tar.gz
-rw-r--r--@ 1 dave  staff   5.8M Apr  6 21:22 riscv-isa-sim--main.arm64_ventura.bottle.15.tar.gz
-rw-r--r--@ 1 dave  staff   252K Apr  6 21:22 riscv-pk--main.arm64_ventura.bottle.13.tar.gz

> shasum -a256 *.tar.gz
815059334a5de53f2eeec849f91d70db2c33c3d33109134154f355eada9bc5f4  riscv-gnu-toolchain--main.arm64_ventura.bottle.13.tar.gz
841e5d077ffa403ebf7c6b7dd3b610e985b2161e7adcbf6aecedf946bdf4c32c  riscv-isa-sim--main.arm64_ventura.bottle.15.tar.gz
f79950ba570e4e984565744e32fe5935bdbcbe71a6beda925aff9997d64df958  riscv-pk--main.arm64_ventura.bottle.13.tar.gz
```

Do you have a place I could upload them? And is there a way for me to test these locally?

[1]: https://github.com/riscv-software-src/homebrew-riscv/files/11175821/results.txt

One last question: Why did you remove the Monterey bottles? I believe the formula can have bottles for both Monterey and Ventura.
