### PR TITLE
enable llvm when gcc is linked to clang

### DIFF
--- a/riscv-gnu-toolchain.rb
+++ b/riscv-gnu-toolchain.rb
@@ -59,6 +59,7 @@ class RiscvGnuToolchain < Formula
     args = [
       "--prefix=#{prefix}",
       "--with-cmodel=medany",
+      "--disable-gdb",
     ]
     args << "--enable-multilib" unless build.with?("NOmultilib")
 


### PR DESCRIPTION
For unknown reason, gdb can't be compiled, since libgmp linking error. This bypass gdb compilation as a workaround.

This solved the issue presented in #102 

closes #104