### PR TITLE
remove unnecessary make install

### DIFF
--- a/riscv-isa-sim.rb
+++ b/riscv-isa-sim.rb
@@ -32,7 +32,6 @@ class RiscvIsaSim < Formula
       # configure uses --with-target to set TARGET_ARCH but homebrew formulas only provide "with"/"without" options
       system "../configure", *args 
       system "make"
-      system "make", "install"
     end
   end
 


### PR DESCRIPTION
In the 'install' target in the Makefile of riscv-gnu-toolchain, it mentions:
"All of the packages install themselves, so our install target does nothing."

See https://github.com/riscv-collab/riscv-gnu-toolchain/blob/master/Makefile.in